### PR TITLE
Text style updates 3

### DIFF
--- a/educator_dashboard/assets/custom.css
+++ b/educator_dashboard/assets/custom.css
@@ -5,8 +5,13 @@
     width: 400px;
 }
 
-.mc-question-summary-table td:first-child {
-    background-color: aqua;
+.mc-question-summary-table .v-data-table__selected {
+    background: var(--md-amber-100) !important;
+}
+
+.mc-individual-student-table .v-data-table__selected {
+    background: var(--md-amber-100) !important;
+
 }
 
 body {
@@ -63,4 +68,8 @@ body {
 }
 #select-a-student-from-the-table-above-to-see-their-responses {
     padding-left: 0.625rem;   
+}
+
+.solara-markdown {
+    padding-left: 0.5rem;
 }

--- a/educator_dashboard/assets/custom.css
+++ b/educator_dashboard/assets/custom.css
@@ -13,10 +13,47 @@ body {
     padding-inline: 5% 
 }
 
-.my-tabs[aria-selected="true"] {
-  background-color: var(--md-blue-400) !important;
+.my-buttons {
+    background-color: var(--md-blue-800) !important;
+    color: white !important;
 }
 
+.vertical-tabs {
+    width: 100%;
+}
+
+.vertical-tabs[aria-selected="true"] {
+    background-color: var(--md-deep-orange-800) !important;
+}
+
+.v-tabs--vertical .v-tabs-slider {
+    color:  var(--md-deep-orange-800);
+}
+
+.horizontal-tabs[aria-selected="true"] {
+    color: var(--md-blue-800) !important;
+    font-weight: 800; 
+}
+
+.v-card__text {
+    color: black !important;
+}
+
+.info-text{
+    padding: 0.5rem;
+}
+
+#h2 {
+    margin-top: 0rem !important;
+}
+
+.v-expansion-panel-header {
+    padding-left: 1rem;
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+/* Disable plotly tools */
 .modebar {
     display: none !important;
 }   
@@ -25,5 +62,5 @@ body {
     padding-left: 0.625rem;  /* 10px @ 16px/rem */
 }
 #select-a-student-from-the-table-above-to-see-their-responses {
-    padding-left: 0.625rem;;   
+    padding-left: 0.625rem;   
 }

--- a/educator_dashboard/components/AgeHistogram.py
+++ b/educator_dashboard/components/AgeHistogram.py
@@ -45,11 +45,11 @@ def AgeHoHistogram(data, which = 'age', subset = None, subset_label = None, subs
     fig.update_traces(marker_color='grey')
     fig.add_trace(go.Bar(x=[None], y=[None], name = 'Full Class', marker_color = 'grey'))
     title = f'Class {which.capitalize()} Distribution' if title is None else title
-    fig.update_layout(showlegend=True, title_text=title)
+    fig.update_layout(showlegend=True, title_text=title, xaxis_showgrid=False, yaxis_showgrid=False, plot_bgcolor="white")
     # show only integers on y-axis
-    fig.update_yaxes(tick0=0, dtick=1)
+    fig.update_yaxes(tick0=0, dtick=1, linecolor="black")
     # show ticks every 1
-    fig.update_xaxes(range=[xmin-1.5, xmax+1.5])
+    fig.update_xaxes(range=[xmin-1.5, xmax+1.5], linecolor="black")
     
     if subset is not None:
         data_subset = data[subset]

--- a/educator_dashboard/components/ClassPlot.py
+++ b/educator_dashboard/components/ClassPlot.py
@@ -51,7 +51,9 @@ def ClassPlot(dataframe,
                y_col: "{label} ({units})".format(**xy_label['y'])}
     fig = px.scatter(dataframe, x=x_col, y=y_col, custom_data = label_col, labels = labels)
     fig.update_traces(marker_color='grey')
-    fig.update_layout(modebar = config)
+    fig.update_layout(modebar = config, title="Class Hubble Diagram", xaxis_showgrid=False, yaxis_showgrid=False, plot_bgcolor="white")
+    fig.update_xaxes(linecolor='black')
+    fig.update_yaxes(linecolor='black')
     # add empty trace to show on legend
     fig.add_trace(go.Scatter(x=[None], y=[None], mode = 'markers', name = 'Full Class', marker_color = 'grey'))
 

--- a/educator_dashboard/components/ClassProgress.py
+++ b/educator_dashboard/components/ClassProgress.py
@@ -1,5 +1,5 @@
 import solara
-from .Collapsable import Collapsable
+from .Collapsible import Collapsible
 
 
 @solara.component
@@ -11,7 +11,7 @@ def ClassProgress(roster):
             solara.Markdown(f"### Error: There are no students in the class {roster.value.class_id}")
             return
         else:
-            with Collapsable(header = "See Class Roster to see what is wrong"):
+            with Collapsible(header = "See Class Roster to see what is wrong"):
                 solara.Markdown(f"Class roster: {roster.value.roster}")
                 return
                 

--- a/educator_dashboard/components/Collapsible.py
+++ b/educator_dashboard/components/Collapsible.py
@@ -2,7 +2,7 @@ import solara
 from solara.alias import rv
 
 @solara.component
-def Collapsable(children = [], header = "Show Table"):
+def Collapsible(children = [], header = "Show Table"):
     with rv.ExpansionPanels():
         with rv.ExpansionPanel():
             with rv.ExpansionPanelHeader():

--- a/educator_dashboard/components/Dashboard.py
+++ b/educator_dashboard/components/Dashboard.py
@@ -88,12 +88,13 @@ def Dashboard(roster, student_names = None):
         with solara.Card():
             solara.Markdown(f"##Student Responses and Data")
 
+            # Heads up: Tabs are considered experimental in Solara and the API may change in the future
             with solara.lab.Tabs(vertical=True, align='right', dark=True, value = show_student_tab):
                 
-                with solara.lab.Tab(label="Class Summary", icon_name="mdi-text-box-outline", classes=["my-tabs"]):
+                with solara.lab.Tab(label="Class Summary", icon_name="mdi-text-box-outline", classes=["vertical-tabs"]):
                     StudentQuestionsSummary(roster, student_id)
                     
-                with solara.lab.Tab(label="Student Responses" if student_id.value is None else f"Student {student_id.value}", classes=["my-tabs"]):
+                with solara.lab.Tab(label="Student Responses" if student_id.value is None else f"Student {student_id.value}", classes=["vertical-tabs"]):
                     IndividualStudentResponses(roster, student_id)
             
                 # with solara.lab.Tab("Student Data", icon_name="mdi-chart-scatter-plot"):

--- a/educator_dashboard/components/DataComponent.py
+++ b/educator_dashboard/components/DataComponent.py
@@ -175,20 +175,31 @@ def StudentData(roster = None, id_col = 'student_id',  sid = None, cols_to_displ
         return
 
 
-    if sid is not None and sid.value is not None:
-        
-        with solara.Row():
-            with solara.Column(gap="0px"):
-                single_student_df = roster.get_student_data(sid.value, df = True)
-                h0 = get_slope(single_student_df['est_dist_value'].to_numpy(), single_student_df['velocity_value'].to_numpy())
-                age = slope2age(h0)
-                solara.Markdown(f"**Hubble Constant**: {h0:.1f} km/s/Mpc")
-                solara.Markdown(f"**Age of Universe**: {age:.1f} Gyr")
-                    
+    if sid is not None and sid.value is not None:        
+        StudentMeasurementTable(roster, sid, headers = cols_to_display)
             
-            StudentMeasurementTable(roster, sid, headers = cols_to_display)
-            
+@solara.component
+def StudentAgeHubble(roster = None, sid = None, allow_id_set = True):
 
+    if isinstance(roster, solara.Reactive):
+        roster = roster.value
+    if roster is None:
+        return
+    
+    dataframe = roster.get_class_data(df = True)
+    if len(dataframe) == 0:
+        solara.Markdown("There is no data for this class")
+        return
+
+    if sid is not None and sid.value is not None:        
+        single_student_df = roster.get_student_data(sid.value, df = True)
+        print("single_student", sid, sid.value, single_student_df)
+        h0 = get_slope(single_student_df['est_dist_value'].to_numpy(), single_student_df['velocity_value'].to_numpy())
+        age = slope2age(h0)
+        solara.Markdown(f"#### Student Age of Universe:")
+        solara.Markdown(f"{age:.0f} Gyr")
+        solara.Markdown(f"#### Student Hubble Constant:")
+        solara.Markdown(f"{h0:.0f} km/s/Mpc")
 
 
 @solara.component
@@ -259,29 +270,37 @@ def StudentDataSummary(roster = None, student_id = None, allow_sid_set = True):
 
     if not isinstance(student_id, solara.Reactive):
         student_id = solara.use_reactive(student_id)
-    
-    with solara.Column():
-        with solara.Column():
-            if 'name' in roster.students.columns:
-                idcol = {'value': 'name', 'text': 'Student Name'}
-            else:
-                idcol = {'value': 'student_id', 'text': 'Student ID'}
-            headers = [
-                idcol,
-                {'value': 'galaxy_id', 'text': 'Galaxy ID'},
-                {'value': 'velocity_value', 'text': 'Velocity <br/> (km/s)'},
-                {'value': 'est_dist_value', 'text': 'Distance <br/> (Mpc)'},
-                {'value': 'obs_wave_value', 'text': 'Observed Wavelength <br/> (Angstrom)'},
-                {'value': 'ang_size_value', 'text': 'Angular Size <br/> (arcsecond)'}
-            ]
-            
-            StudentData(roster, id_col="student_id", sid = student_id, cols_to_display = headers, allow_id_set = allow_sid_set)
-                          
-                          
+
+    with solara.Row():
         with solara.Columns([1,1]):
-            with solara.Column():
+            with solara.Card(style='height: 95%'):
                 DataSummary(roster, student_id, allow_click=allow_sid_set)
-            with solara.Column():
+
+            with solara.Card(style='height: 95%'):
                 DataHistogram(roster, sid = student_id)
+
+    if student_id is not None and student_id.value is not None:
+        with solara.Row():
+            with solara.Columns([1,1]):
+                with solara.Card(style='height: 90%'):
+                    solara.Markdown(f"#### Student Galaxy Measurements")
+                    
+                    headers = [
+                        {'value': 'galaxy_id', 'text': 'Galaxy ID'},
+                        {'value': 'obs_wave_value', 'text': 'Observed Wavelength <br/> (Angstrom)'},
+                        {'value': 'velocity_value', 'text': 'Velocity <br/> (km/s)'},
+                        {'value': 'ang_size_value', 'text': 'Angular Size <br/> (arcsecond)'},
+                        {'value': 'est_dist_value', 'text': 'Distance <br/> (Mpc)'},
+                    ]
+                    
+                    StudentData(roster, id_col="student_id", sid = student_id, cols_to_display = headers, allow_id_set = allow_sid_set)
+
+                with solara.Card(style='height: 90%'):
+                    StudentAgeHubble(roster, sid = student_id)
+
+        
+                          
+                          
+
         
           

--- a/educator_dashboard/components/FreeResponse.py
+++ b/educator_dashboard/components/FreeResponse.py
@@ -87,7 +87,7 @@ def FreeResponseSummary(roster):
     stages = list(filter(lambda s: s.isdigit(),sorted(fr_questions.keys())))
     
 
-    with solara.Columns([3, 1]):
+    with solara.Columns([5, 1], style={"height": "100%"}):
         with solara.Column():
             for stage in stages:     
                 question_responses = roster.l2d(fr_questions[stage]) # {'key': ['response1', 'response2',...]}

--- a/educator_dashboard/components/FreeResponse.py
+++ b/educator_dashboard/components/FreeResponse.py
@@ -4,7 +4,7 @@ from solara.alias import rv
 
 from pandas import DataFrame
 
-from .Collapsable import Collapsable
+from .Collapsible import Collapsible
 
 from ..database.Query import QueryCosmicDSApi as Query
 

--- a/educator_dashboard/components/FreeResponse.py
+++ b/educator_dashboard/components/FreeResponse.py
@@ -13,7 +13,7 @@ from ..database.Query import QueryCosmicDSApi as Query
 
 @solara.component_vue('FreeResponseQuestion.vue')
 def FreeResponseQuestion(question='', shortquestion='', responses=[], names = [],
-                         hideShortQuestion = False, hideQuestion = False, hideResponses = False):
+                         hideShortQuestion = False, hideQuestion = False, hideResponses = False, hideName = False):
     """
     free_response = {
         'question': '',
@@ -25,7 +25,7 @@ def FreeResponseQuestion(question='', shortquestion='', responses=[], names = []
 
 @solara.component
 def FreeResponseQuestionResponseSummary(question_responses, question_text, names = None,
-                                        hideShortQuestion = False, hideQuestion = False, hideResponses = False
+                                        hideShortQuestion = False, hideQuestion = False, hideResponses = False, hideName = False
                                         ):
     """
     question_responses = {'key': ['response1', 'response2',...]}
@@ -69,7 +69,8 @@ def FreeResponseQuestionResponseSummary(question_responses, question_text, names
                                              names = names,
                                              hideShortQuestion = hideShortQuestion, 
                                              hideQuestion = hideQuestion, 
-                                             hideResponses = hideResponses)
+                                             hideResponses = hideResponses,
+                                             hideName = hideName)
 
 
 @solara.component
@@ -140,5 +141,6 @@ def FreeResponseQuestionSingleStudent(roster, sid = None):
                                 shortquestion = shortquestion, 
                                 responses = responses, 
                                 hideShortQuestion = True,
+                                hideName = True
                                 )
         

--- a/educator_dashboard/components/FreeResponseQuestion.vue
+++ b/educator_dashboard/components/FreeResponseQuestion.vue
@@ -126,8 +126,7 @@ export default {
 }
 .question {
   display: inline-block;
-  font-weight: bold;  
-  color: rgb(118, 118, 118);
+  color: black;
 }
 
 .response-row {
@@ -137,18 +136,23 @@ export default {
   grid-template-rows: auto;
   gap: 0.1rem;
   margin-top: 0.5rem;
-  border-bottom: 1px solid rgb(118, 118, 118);
 }
 
 .response-item {
   display: inline-block;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--md-grey-900);
+  background-color: var(--md-amber-100);
 
 }
 
 .name-item {
   display: inline-block;
   font-weight: bold;
-  color: rgb(118, 118, 118);
+  color: var(--md-grey-900);
+  padding-left: 0.5rem;
+  margin-top: 1rem;
 
 }
 </style>

--- a/educator_dashboard/components/FreeResponseQuestion.vue
+++ b/educator_dashboard/components/FreeResponseQuestion.vue
@@ -9,7 +9,7 @@
         </div>
 
         <div  v-if="!hideResponses" class="response-row" v-for="(response, index) in responseList">
-          <div class="name-item" v-if="names != null" >
+          <div class="name-item" v-if="names != null && !hideName" >
             {{ getName(index) }}
           </div>
             <div class="response-item">
@@ -57,6 +57,11 @@ export default {
     },
 
     hideResponses: {
+      type: Boolean,
+      default: false
+    },
+
+    hideName: {
       type: Boolean,
       default: false
     },

--- a/educator_dashboard/components/MultipleChoice.py
+++ b/educator_dashboard/components/MultipleChoice.py
@@ -90,7 +90,7 @@ def MultipleChoiceStageSummary(roster, stage = None):
                         fig.update_xaxes(type='category')
                         solara.FigurePlotly(fig)
                                         
-                with Collapsable(header='Show Table'):
+                with Collapsable(header='Individual Student Tries for Question'):
                     if 'name' in roster.students.columns:
                         headers = [{'text': 'Name', 'value': 'name'}, {'text': 'Tries', 'value': 'tries'}]
                         # add names to df

--- a/educator_dashboard/components/MultipleChoice.py
+++ b/educator_dashboard/components/MultipleChoice.py
@@ -73,6 +73,7 @@ def MultipleChoiceStageSummary(roster, stage = None):
                 items=data_values,
                 on_row_click=on_change,
                 show_index=True,
+                class_ = "mc-question-summary-table"
             )
 
         with solara.Columns([1,1]):
@@ -172,14 +173,15 @@ def MultipleChoiceQuestionSingleStage(df = None, headers = None, stage = 0):
                         """.format(stage, completed, total, points, total_points, avg_tries))    
         
     with solara.Row():
-        with solara.Columns([1,2]):
+        with solara.Columns([1,1]):
             with solara.Column():
-                if dquest is not None:
+                if len(dquest)>0:
                     solara.Markdown(f"**Question**: {dquest}")
                 else:
-                    solara.Markdown(f"**Select a question from table** ")
+                    solara.Markdown(f"**Select a row from table to see full question text.** ")
             with solara.Column():
-                DataTable(df = df, headers = headers, on_row_click=row_action, show_index=True)
+                DataTable(df = df, headers = headers, on_row_click=row_action, show_index=True, class_ = "mc-individual-student-table")
+    rv.Divider()
             
 
         
@@ -218,6 +220,5 @@ def MultipleChoiceQuestionSingleStudent(roster, sid = None):
             {'text': 'Tries', 'value': 'tries'},
             {'text': 'Score', 'value': 'score'},
         ]
-        with solara.Card():
-            MultipleChoiceQuestionSingleStage(df = df, headers = headers, stage = stage)
+        MultipleChoiceQuestionSingleStage(df = df, headers = headers, stage = stage)
             

--- a/educator_dashboard/components/MultipleChoice.py
+++ b/educator_dashboard/components/MultipleChoice.py
@@ -5,7 +5,7 @@ import reacton.ipyvuetify as rv
 from pandas import DataFrame, Series, concat
 from ..database.Query import QueryCosmicDSApi as Query
 import plotly.express as px
-from .Collapsable import Collapsable
+from .Collapsible import Collapsible
 
 from .TableComponents import DataTable
 
@@ -90,7 +90,7 @@ def MultipleChoiceStageSummary(roster, stage = None):
                         fig.update_xaxes(type='category')
                         solara.FigurePlotly(fig)
                                         
-                with Collapsable(header='Individual Student Tries for Question'):
+                with Collapsible(header='Individual Student Tries for Question'):
                     if 'name' in roster.students.columns:
                         headers = [{'text': 'Name', 'value': 'name'}, {'text': 'Tries', 'value': 'tries'}]
                         # add names to df

--- a/educator_dashboard/components/ProgressRow/ProgressRow.vue
+++ b/educator_dashboard/components/ProgressRow/ProgressRow.vue
@@ -137,7 +137,7 @@ export default {
 }
 
 .progress-table-row-selected {
-  background-color: #d7d7d7 !important;
+  background-color: var(--md-amber-100) !important;
 }
 
 .progress-table-progress {
@@ -166,27 +166,27 @@ export default {
 }
 
 .completed {
-  background-color: hsl(122, 39%, 50%);
+  background-color: var(--md-deep-orange-500);
   
 }
 
 .completed-lighter {
-  background-color: hsl(122, 39%, 80%)}
+  background-color: var(--md-deep-orange-500)}
 
 .in-progress {
-  background-color: hsl(122, 39%, 50%);
+  background-color: var(--md-deep-orange-500);
 }
 
 .in-progress-lighter {
-  background-color: hsl(57, 70%, 50%);;
+  background-color: var(--md-cyan-300);
 }
 
 .not-started {
-  background-color: hsl(57, 70%, 50%);
+  background-color: var(--md-cyan-300);
 }
 
 .not-started-lighter {
-  background-color: hsl(57, 70%, 50%);;
+  background-color: var(--md-cyan-300);
 }
 
 </style>

--- a/educator_dashboard/components/ResponsesComponents.py
+++ b/educator_dashboard/components/ResponsesComponents.py
@@ -28,15 +28,15 @@ def IndividualStudentResponses(roster, sid=None):
     
     # multiple choice questions
     with solara.lab.Tabs():
-        with solara.lab.Tab("Multiple Choice"):
-            with ScrollY(height='50vh'):
+        with solara.lab.Tab("Multiple Choice", classes=["horizontal-tabs"]):
+            with ScrollY(height='55vh'):
                 MultipleChoiceQuestionSingleStudent(roster, sid = sid)
             
-        with solara.lab.Tab("Free Response"):
-            with ScrollY(height='50vh'):
+        with solara.lab.Tab("Free Response", classes=["horizontal-tabs"]):
+            with ScrollY(height='55vh'):
                 FreeResponseQuestionSingleStudent(roster, sid = sid)
         
-        with solara.lab.Tab("Data"):
+        with solara.lab.Tab("Data", classes=["horizontal-tabs"]):
             StudentDataSummary(roster, student_id = sid.value, allow_sid_set=False)
 
 
@@ -49,15 +49,15 @@ def StudentQuestionsSummary(roster, sid = None):
             return
 
     with solara.lab.Tabs():
-        with solara.lab.Tab("Multiple Choice"):
+        with solara.lab.Tab("Multiple Choice", classes=["horizontal-tabs"]):
             # if not empty_class:
             solara.Markdown(f"####  Click any row for more detailed question information.")
-            with ScrollY(height='50vh'):
+            with ScrollY(height='55vh'):
                 MultipleChoiceSummary(roster)
             
-        with solara.lab.Tab("Free Response"):
-            with ScrollY(height='50vh'):
+        with solara.lab.Tab("Free Response", classes=["horizontal-tabs"]):
+            with ScrollY(height='55vh'):
                 FreeResponseSummary(roster)
         
-        with solara.lab.Tab("Data"):
+        with solara.lab.Tab("Data", classes=["horizontal-tabs"]):
             StudentDataSummary(roster, student_id = None, allow_sid_set=False)

--- a/educator_dashboard/components/StudentDataLoad.py
+++ b/educator_dashboard/components/StudentDataLoad.py
@@ -53,7 +53,7 @@ def StudentNameLoad(roster = None, student_names = None, on_update = None):
             'variable': 'dummy_var',
             'children': 
                 solara.Tooltip(tooltip="Use local csv file to convert IDs to names", 
-                    children = [solara.Button(label = "ID -> Name Translation", on_click = lambda: dialog_open.set(True), color='primary')]
+                    children = [solara.Button(label = "ID -> Name Translation", on_click = lambda: dialog_open.set(True), classes=["my-buttons"])]
                 )
         }]
     )

--- a/educator_dashboard/components/TableComponents/DataTable.vue
+++ b/educator_dashboard/components/TableComponents/DataTable.vue
@@ -123,18 +123,3 @@ export default {
 
 
 </script>
-
-<style>
-  tr.v-data-table__selected {
-    background: #d7d7d7 !important;
-  }
-  
-  .dashboard-table tr th:first-of-type {
-    width: 3ch;
-  }
-  
-  .dashboard-table tr td:first-of-type {
-    width: 3ch;
-  }
-  
-</style>

--- a/educator_dashboard/components/TableFromRows.vue
+++ b/educator_dashboard/components/TableFromRows.vue
@@ -50,6 +50,7 @@ export default {
 
 #table-from-rows {
   position: relative;
+  margin-top: 0.75rem;
 }
 
 #table-from-rows > table {
@@ -69,15 +70,15 @@ export default {
 .fixed_header_table_wrapper > table > thead {
   position: sticky;
   top: 0;
-  background-color: #f2f2f2;
-  color: black;
+  background-color: var(--md-blue-800);
+  color: white;
   z-index: 2;
 }
 
 
 
 #table-from-rows tr:hover {
-  background-color: #ededed;
+  background-color: var(--md-grey-300);
 }
 
 #table-from-rows tbody > tr {
@@ -89,8 +90,4 @@ export default {
   text-align: center;
 }
 
-/* every other row */
-#table-from-rows tbody > tr:nth-child(odd):not(:hover) {
-  background-color: #fff2a944;
-}
 </style>

--- a/educator_dashboard/components/TableFromRows.vue
+++ b/educator_dashboard/components/TableFromRows.vue
@@ -81,8 +81,10 @@ export default {
   background-color: var(--md-grey-300);
 }
 
-#table-from-rows tbody > tr {
-  border-bottom: 1px solid #d7d7d7;
+
+
+#table-from-rows thead>tr:hover {
+  background-color: unset;
 }
 
 #table-from-rows td, th {


### PR DESCRIPTION
- Update color scheme to match hubbleds
- Apply @heywooddogwood's fix for Free Response Class Summary issue where the breadcrumbs toggler scrolls out of view
- Update tables and free response styling to have a more unified look
- Adjust layout for Multiple Choice tab in single student view
- Show rounded integer # of tries in table of students for a given question. If they didn't answer question, display blank instead of NaN
- Update Data Layouts onto cards in rows and columns
- Start updating some of the plotly styling, but will add more after merging in #35.