### PR TITLE
Add dotenv to requirements.txt

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -2,4 +2,5 @@ solara
 pandas
 plotly
 astropy
+python-dotenv
 educator_dashboard @ git+https://github.com/cosmicds/educator_dashboard.git


### PR DESCRIPTION
For deploying the dashboard, we need `python-dotenv` in the `requirements.txt` file.