### PR TITLE
properly catch empty return

### DIFF
--- a/educator_dashboard/class_report.py
+++ b/educator_dashboard/class_report.py
@@ -277,6 +277,8 @@ class Roster():
     def get_class_data(self, refresh: bool = False, df: bool = False) -> Union[Dict, pd.DataFrame]:
         if self.data is None or self._refresh or refresh:
             res = self.query.get_class_data(class_id=self.class_id)
+            if res is None or res == {} or len(res) == 0:
+                res = {'student_id': []}
             self.data = res if res is not None else {'student_id': []}
             if len(self.student_data) == 0:
                 groupdf = pd.DataFrame(self.data).groupby('student_id')


### PR DESCRIPTION
The get class query no longer turns a `None`, but `{}`. I'm not sure what exactly state is the cause of this, but this allows the dashboard to handle it the way it was supposed to. 