### PR TITLE
remove instruction that is no longer true and update css

### DIFF
--- a/educator_dashboard/assets/custom.css
+++ b/educator_dashboard/assets/custom.css
@@ -88,9 +88,10 @@
     min-width: 200px;
 }
 
-.cds-dashboard .my-cards {
+.dash-card {
     max-width: 98%;
     padding: 10px;
+    border: 1px solid var(--info) !important;
 }
 
 .cds-dashboard .v-dialog {
@@ -101,7 +102,7 @@
     margin-block: 10px;
 }
 
-.cds-dashboard .dialog-button {
+.dash-dialog-button {
     position:absolute;
     right: 1.5rem;
     bottom: 0.5rem;

--- a/educator_dashboard/components/FileLoad.py
+++ b/educator_dashboard/components/FileLoad.py
@@ -45,7 +45,6 @@ def TableLoad(file_info = None, load_complete = None, allow_excel = False):
                         
             * Include a header row with column names 'student_id' and 'name'. 
             * To protect student privacy, this information remains on your computer and will NOT be uploaded to CosmicDS servers.
-            * You can load a single name file that includes students from multiple classes, and they will be applied when the relevant class is viewed. (If you use separate name files for each class, you will need to reload the file every time you toggle between classes).
         ''')
         if not load_complete.value:
             solara.FileDrop(

--- a/educator_dashboard/components/StudentDataLoad.py
+++ b/educator_dashboard/components/StudentDataLoad.py
@@ -75,7 +75,7 @@ def StudentLoadDialog(student_names = None, student_names_set = None, dialog_ope
     )
     comp = dialog if not no_dialog else solara.Div()
     with comp:
-        with solara.Card(classes=["my-cards"]):
+        with solara.Card(classes=["dash-card"]):
             StudentDataLoadInterface(student_names, table_set = student_names_set)
             
             table_valid.set(validator(student_names.value))
@@ -95,7 +95,7 @@ def StudentLoadDialog(student_names = None, student_names_set = None, dialog_ope
             
                 
             with solara.CardActions():
-                solara.Button(icon_name="mdi-close-circle",label = "Close", on_click = lambda: dialog_open.set(False), text=True, outlined=True, classes=["dialog-button"])
+                solara.Button(icon_name="mdi-close-circle",label = "Close", on_click = lambda: dialog_open.set(False), text=True, outlined=True, classes=["dash-dialog-button"])
 
 
 def validate_table(table, required_sids):


### PR DESCRIPTION
It looks like the dashboard css relies on the fact that the whole dashboard page should have a `.cds-dashboard` class applied at the top level. In the deployed portal+dashboard, I don't see that top level class on the dashboard, so much of the css classes are not being properly applied to the dashboard. 

This adds a couple new classes that only get used in the dashboard.